### PR TITLE
Fix blank book cover when returning from detail via predictive back

### DIFF
--- a/lib/core/navigation/app_route_launcher.dart
+++ b/lib/core/navigation/app_route_launcher.dart
@@ -4,6 +4,47 @@ import 'package:novella/core/layout/app_window_class.dart';
 
 typedef AppPageBuilder = Widget Function(BuildContext context);
 
+/// On Android, forces [ZoomPageTransitionsBuilder] for Hero-bearing detail
+/// pages: the predictive-back preview conflicts with Hero flight and can leave
+/// the list cover blank, so back falls back to a normal pop. Other platforms
+/// keep the theme default.
+class _HeroSafePageRoute<T> extends MaterialPageRoute<T> {
+  _HeroSafePageRoute({
+    required super.builder,
+    super.settings,
+    super.maintainState,
+    super.fullscreenDialog,
+  });
+
+  static const PageTransitionsBuilder _transitions =
+      ZoomPageTransitionsBuilder();
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    // Only Android has the predictive-back conflict; keep the theme default elsewhere (e.g. iOS swipe-back)
+    if (Theme.of(context).platform != TargetPlatform.android) {
+      return super.buildTransitions(
+        context,
+        animation,
+        secondaryAnimation,
+        child,
+      );
+    }
+    return _transitions.buildTransitions<T>(
+      this,
+      context,
+      animation,
+      secondaryAnimation,
+      child,
+    );
+  }
+}
+
 class AppPaneCoordinator {
   AppPaneCoordinator({required int tabCount})
     : _navigatorKeys = List<GlobalKey<NavigatorState>>.generate(
@@ -119,13 +160,23 @@ class AppRouteLauncher {
     RouteSettings? settings,
     bool maintainState = true,
     bool fullscreenDialog = false,
+    bool heroTransition = false,
   }) {
-    final route = MaterialPageRoute<T>(
-      builder: builder,
-      settings: settings,
-      maintainState: maintainState,
-      fullscreenDialog: fullscreenDialog,
-    );
+    // Hero pages need the Zoom transition to avoid the predictive-back conflict; see _HeroSafePageRoute
+    final route =
+        heroTransition
+            ? _HeroSafePageRoute<T>(
+              builder: builder,
+              settings: settings,
+              maintainState: maintainState,
+              fullscreenDialog: fullscreenDialog,
+            )
+            : MaterialPageRoute<T>(
+              builder: builder,
+              settings: settings,
+              maintainState: maintainState,
+              fullscreenDialog: fullscreenDialog,
+            );
 
     final windowScope = AppWindowScope.maybeOf(context);
     final tabScope = AppPaneTabScope.maybeOf(context);

--- a/lib/features/history/history_page.dart
+++ b/lib/features/history/history_page.dart
@@ -682,6 +682,7 @@ class HistoryPageState extends ConsumerState<HistoryPage> {
             heroTag: heroTag,
             telemetrySource: TelemetryBookDetailSources.history,
           ),
+          heroTransition: true,
         ).then((_) {
           if (mounted) {
             _fetchHistory(force: true, silentIfPossible: true);

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -801,6 +801,7 @@ class HomePageState extends ConsumerState<HomePage> with RouteAware {
                         telemetrySource:
                             TelemetryBookDetailSources.homeContinueReading,
                       ),
+                      heroTransition: true,
                     ).then((_) {
                       _loadReadingStats();
                       _fetchContinueReading(internalLoading: false);
@@ -1206,6 +1207,7 @@ class HomePageState extends ConsumerState<HomePage> with RouteAware {
             heroTag: heroTag,
             telemetrySource: telemetrySource,
           ),
+          heroTransition: true,
         ).then((_) {
           _loadReadingStats();
           _fetchContinueReading(internalLoading: false);

--- a/lib/features/home/recently_updated_page.dart
+++ b/lib/features/home/recently_updated_page.dart
@@ -256,6 +256,7 @@ class _RecentlyUpdatedPageState extends ConsumerState<RecentlyUpdatedPage> {
             heroTag: heroTag,
             telemetrySource: TelemetryBookDetailSources.homeRecentlyUpdated,
           ),
+          heroTransition: true,
         );
       },
       child: Column(

--- a/lib/features/ranking/ranking_page.dart
+++ b/lib/features/ranking/ranking_page.dart
@@ -248,6 +248,7 @@ class _RankingPageState extends ConsumerState<RankingPage>
             heroTag: heroTag,
             telemetrySource: TelemetryBookDetailSources.ranking,
           ),
+          heroTransition: true,
         );
       },
       child: Column(

--- a/lib/features/search/search_page.dart
+++ b/lib/features/search/search_page.dart
@@ -759,6 +759,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
             heroTag: heroTag,
             telemetrySource: TelemetryBookDetailSources.search,
           ),
+          heroTransition: true,
         );
       },
       child: Column(

--- a/lib/features/shelf/shelf_folder_page.dart
+++ b/lib/features/shelf/shelf_folder_page.dart
@@ -557,6 +557,7 @@ class _ShelfFolderPageState extends ConsumerState<ShelfFolderPage> {
         heroTag: 'shelf_folder_${widget.folderId}_$bookId',
         telemetrySource: TelemetryBookDetailSources.shelfFolder,
       ),
+      heroTransition: true,
     );
   }
 

--- a/lib/features/shelf/shelf_page.dart
+++ b/lib/features/shelf/shelf_page.dart
@@ -731,6 +731,7 @@ class ShelfPageState extends ConsumerState<ShelfPage> {
         heroTag: 'shelf_cover_$bookId',
         telemetrySource: TelemetryBookDetailSources.shelf,
       ),
+      heroTransition: true,
     );
 
     await _refreshGrid(silentIfPossible: true);


### PR DESCRIPTION
## Problem
On Android, returning from the book detail page to a list occasionally shows a blank cover in the list grid cell. Root cause: the conflict between the Hero animation and Android's predictive back gesture.

## Root cause
Since Flutter 3.27 the default Android page transition is `PredictiveBackPageTransitionsBuilder`, and the manifest has `enableOnBackInvokedCallback=true`. Predictive back animates the whole page as a unit driven by the system gesture, which is incompatible with Hero's shared-element flight. On gesture commit/cancel the list-side Hero placeholder (an invisible `SizedBox` during flight) is sometimes left unrestored, so the cover renders blank.

## Fix
`BookDetailPage` is the only pushed route that is a Hero flight target, and it is always launched via `AppRouteLauncher.pushDetail`. Added a `MaterialPageRoute` subclass (`_HeroSafePageRoute`) that forces `ZoomPageTransitionsBuilder`, and a `heroTransition` flag on `pushDetail` (default `false`). The 8 `BookDetailPage` call sites pass `heroTransition: true`. Back gestures on the detail route now fall back to a normal pop so the Hero flight completes correctly.

Predictive back is preserved for all non-Hero routes (settings, community, list pages), so the UX regression is minimal.

## Testing
- `flutter analyze` clean on all changed files.
- Deployed a debug build to a physical device (Android 16 / API 36) via `flutter run`.