### PR TITLE
Fix blank covers after rapid back navigation

### DIFF
--- a/lib/core/navigation/app_route_launcher.dart
+++ b/lib/core/navigation/app_route_launcher.dart
@@ -4,47 +4,6 @@ import 'package:novella/core/layout/app_window_class.dart';
 
 typedef AppPageBuilder = Widget Function(BuildContext context);
 
-/// On Android, forces [ZoomPageTransitionsBuilder] for Hero-bearing detail
-/// pages: the predictive-back preview conflicts with Hero flight and can leave
-/// the list cover blank, so back falls back to a normal pop. Other platforms
-/// keep the theme default.
-class _HeroSafePageRoute<T> extends MaterialPageRoute<T> {
-  _HeroSafePageRoute({
-    required super.builder,
-    super.settings,
-    super.maintainState,
-    super.fullscreenDialog,
-  });
-
-  static const PageTransitionsBuilder _transitions =
-      ZoomPageTransitionsBuilder();
-
-  @override
-  Widget buildTransitions(
-    BuildContext context,
-    Animation<double> animation,
-    Animation<double> secondaryAnimation,
-    Widget child,
-  ) {
-    // Only Android has the predictive-back conflict; keep the theme default elsewhere (e.g. iOS swipe-back)
-    if (Theme.of(context).platform != TargetPlatform.android) {
-      return super.buildTransitions(
-        context,
-        animation,
-        secondaryAnimation,
-        child,
-      );
-    }
-    return _transitions.buildTransitions<T>(
-      this,
-      context,
-      animation,
-      secondaryAnimation,
-      child,
-    );
-  }
-}
-
 class AppPaneCoordinator {
   AppPaneCoordinator({required int tabCount})
     : _navigatorKeys = List<GlobalKey<NavigatorState>>.generate(
@@ -160,23 +119,13 @@ class AppRouteLauncher {
     RouteSettings? settings,
     bool maintainState = true,
     bool fullscreenDialog = false,
-    bool heroTransition = false,
   }) {
-    // Hero pages need the Zoom transition to avoid the predictive-back conflict; see _HeroSafePageRoute
-    final route =
-        heroTransition
-            ? _HeroSafePageRoute<T>(
-              builder: builder,
-              settings: settings,
-              maintainState: maintainState,
-              fullscreenDialog: fullscreenDialog,
-            )
-            : MaterialPageRoute<T>(
-              builder: builder,
-              settings: settings,
-              maintainState: maintainState,
-              fullscreenDialog: fullscreenDialog,
-            );
+    final route = MaterialPageRoute<T>(
+      builder: builder,
+      settings: settings,
+      maintainState: maintainState,
+      fullscreenDialog: fullscreenDialog,
+    );
 
     final windowScope = AppWindowScope.maybeOf(context);
     final tabScope = AppPaneTabScope.maybeOf(context);

--- a/lib/features/history/history_page.dart
+++ b/lib/features/history/history_page.dart
@@ -679,7 +679,6 @@ class HistoryPageState extends ConsumerState<HistoryPage> {
             heroTag: heroTag,
             telemetrySource: TelemetryBookDetailSources.history,
           ),
-          heroTransition: true,
         ).then((_) {
           if (mounted) {
             _fetchHistory(force: true, silentIfPossible: true);

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -805,7 +805,6 @@ class HomePageState extends ConsumerState<HomePage> with RouteAware {
                         telemetrySource:
                             TelemetryBookDetailSources.homeContinueReading,
                       ),
-                      heroTransition: true,
                     ).then((_) {
                       _loadReadingStats();
                       _fetchContinueReading(internalLoading: false);
@@ -818,6 +817,7 @@ class HomePageState extends ConsumerState<HomePage> with RouteAware {
                         // 封面
                         Hero(
                           tag: 'continue_reading_${book.id}',
+                          placeholderBuilder: bookCoverHeroPlaceholderBuilder,
                           // 冷启动首次点击时，详情页封面可能仍在占位阶段。
                           // 这里 push 阶段强制使用来源 Hero（首页侧）作为飞行物，
                           // 避免 Hero 飞行过程中从“真实封面”变成“灰色占位”造成观感退化。
@@ -1211,7 +1211,6 @@ class HomePageState extends ConsumerState<HomePage> with RouteAware {
             heroTag: heroTag,
             telemetrySource: telemetrySource,
           ),
-          heroTransition: true,
         ).then((_) {
           _loadReadingStats();
           _fetchContinueReading(internalLoading: false);
@@ -1223,6 +1222,7 @@ class HomePageState extends ConsumerState<HomePage> with RouteAware {
           Expanded(
             child: Hero(
               tag: heroTag,
+              placeholderBuilder: bookCoverHeroPlaceholderBuilder,
               child: BookCoverCard(
                 coverUrl: book.cover,
                 overlays: [

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -815,9 +815,8 @@ class HomePageState extends ConsumerState<HomePage> with RouteAware {
                     child: Row(
                       children: [
                         // 封面
-                        Hero(
+                        BookCoverHero(
                           tag: 'continue_reading_${book.id}',
-                          placeholderBuilder: bookCoverHeroPlaceholderBuilder,
                           // 冷启动首次点击时，详情页封面可能仍在占位阶段。
                           // 这里 push 阶段强制使用来源 Hero（首页侧）作为飞行物，
                           // 避免 Hero 飞行过程中从“真实封面”变成“灰色占位”造成观感退化。
@@ -1220,9 +1219,8 @@ class HomePageState extends ConsumerState<HomePage> with RouteAware {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Expanded(
-            child: Hero(
+            child: BookCoverHero(
               tag: heroTag,
-              placeholderBuilder: bookCoverHeroPlaceholderBuilder,
               child: BookCoverCard(
                 coverUrl: book.cover,
                 overlays: [

--- a/lib/features/home/recently_updated_page.dart
+++ b/lib/features/home/recently_updated_page.dart
@@ -256,9 +256,8 @@ class _RecentlyUpdatedPageState extends ConsumerState<RecentlyUpdatedPage> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Expanded(
-            child: Hero(
+            child: BookCoverHero(
               tag: heroTag,
-              placeholderBuilder: bookCoverHeroPlaceholderBuilder,
               child: BookCoverCard(
                 coverUrl: book.cover,
                 overlays: [

--- a/lib/features/home/recently_updated_page.dart
+++ b/lib/features/home/recently_updated_page.dart
@@ -250,7 +250,6 @@ class _RecentlyUpdatedPageState extends ConsumerState<RecentlyUpdatedPage> {
             heroTag: heroTag,
             telemetrySource: TelemetryBookDetailSources.homeRecentlyUpdated,
           ),
-          heroTransition: true,
         );
       },
       child: Column(
@@ -259,6 +258,7 @@ class _RecentlyUpdatedPageState extends ConsumerState<RecentlyUpdatedPage> {
           Expanded(
             child: Hero(
               tag: heroTag,
+              placeholderBuilder: bookCoverHeroPlaceholderBuilder,
               child: BookCoverCard(
                 coverUrl: book.cover,
                 overlays: [

--- a/lib/features/ranking/ranking_page.dart
+++ b/lib/features/ranking/ranking_page.dart
@@ -249,7 +249,6 @@ class _RankingPageState extends ConsumerState<RankingPage>
             heroTag: heroTag,
             telemetrySource: TelemetryBookDetailSources.ranking,
           ),
-          heroTransition: true,
         );
       },
       child: Column(
@@ -258,6 +257,7 @@ class _RankingPageState extends ConsumerState<RankingPage>
           Expanded(
             child: Hero(
               tag: heroTag,
+              placeholderBuilder: bookCoverHeroPlaceholderBuilder,
               child: BookCoverCard(
                 coverUrl: book.cover,
                 overlays: [

--- a/lib/features/ranking/ranking_page.dart
+++ b/lib/features/ranking/ranking_page.dart
@@ -255,9 +255,8 @@ class _RankingPageState extends ConsumerState<RankingPage>
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Expanded(
-            child: Hero(
+            child: BookCoverHero(
               tag: heroTag,
-              placeholderBuilder: bookCoverHeroPlaceholderBuilder,
               child: BookCoverCard(
                 coverUrl: book.cover,
                 overlays: [

--- a/lib/features/search/search_page.dart
+++ b/lib/features/search/search_page.dart
@@ -759,7 +759,6 @@ class _SearchPageState extends ConsumerState<SearchPage> {
             heroTag: heroTag,
             telemetrySource: TelemetryBookDetailSources.search,
           ),
-          heroTransition: true,
         );
       },
       child: Column(
@@ -768,6 +767,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
           Expanded(
             child: Hero(
               tag: heroTag,
+              placeholderBuilder: bookCoverHeroPlaceholderBuilder,
               child: BookCoverCard(
                 coverUrl: book.cover,
                 overlays: [

--- a/lib/features/search/search_page.dart
+++ b/lib/features/search/search_page.dart
@@ -215,21 +215,20 @@ class _SearchPageState extends ConsumerState<SearchPage> {
   Future<void> _clearHistory() async {
     final confirmed = await showDialog<bool>(
       context: context,
-      builder:
-          (context) => AlertDialog(
-            title: const Text('清空搜索历史'),
-            content: const Text('确定要清空所有搜索记录吗？'),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(context, false),
-                child: const Text('取消'),
-              ),
-              FilledButton(
-                onPressed: () => Navigator.pop(context, true),
-                child: const Text('清空'),
-              ),
-            ],
+      builder: (context) => AlertDialog(
+        title: const Text('清空搜索历史'),
+        content: const Text('确定要清空所有搜索记录吗？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('取消'),
           ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('清空'),
+          ),
+        ],
+      ),
     );
 
     if (confirmed == true) {
@@ -248,8 +247,8 @@ class _SearchPageState extends ConsumerState<SearchPage> {
     if (keyword.isEmpty) return;
     final effectiveMode =
         mode == BookSearchMode.fuzzy && isQuotedBookSearchKeyword(keyword)
-            ? BookSearchMode.exact
-            : mode;
+        ? BookSearchMode.exact
+        : mode;
 
     // 收起键盘
     FocusScope.of(context).unfocus();
@@ -351,10 +350,9 @@ class _SearchPageState extends ConsumerState<SearchPage> {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           FilledButton.tonalIcon(
-            onPressed:
-                _currentFrontendPage > 1 && !_loading
-                    ? () => _fetchPage(_currentFrontendPage - 1)
-                    : null,
+            onPressed: _currentFrontendPage > 1 && !_loading
+                ? () => _fetchPage(_currentFrontendPage - 1)
+                : null,
             icon: const Icon(Icons.navigate_before),
             label: const Text('上一页'),
           ),
@@ -368,10 +366,9 @@ class _SearchPageState extends ConsumerState<SearchPage> {
           ),
           const SizedBox(width: 16),
           FilledButton.tonalIcon(
-            onPressed:
-                _canGoNext && !_loading
-                    ? () => _fetchPage(_currentFrontendPage + 1)
-                    : null,
+            onPressed: _canGoNext && !_loading
+                ? () => _fetchPage(_currentFrontendPage + 1)
+                : null,
             icon: const Icon(Icons.navigate_next),
             label: const Text('下一页'),
           ),
@@ -454,10 +451,9 @@ class _SearchPageState extends ConsumerState<SearchPage> {
           IconButton(
             tooltip: _searchOptionsExpanded ? '收起搜索方式' : '搜索方式',
             icon: Icon(_searchOptionsExpanded ? Icons.expand_less : Icons.tune),
-            onPressed:
-                () => setState(() {
-                  _searchOptionsExpanded = !_searchOptionsExpanded;
-                }),
+            onPressed: () => setState(() {
+              _searchOptionsExpanded = !_searchOptionsExpanded;
+            }),
           ),
           IconButton(
             tooltip: '搜索',
@@ -495,13 +491,12 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                 child: FadeTransition(opacity: animation, child: child),
               );
             },
-            child:
-                _searchOptionsExpanded
-                    ? _buildSearchModePanel(colorScheme, textTheme)
-                    : const SizedBox(
-                      key: ValueKey('search_mode_panel_empty'),
-                      width: double.infinity,
-                    ),
+            child: _searchOptionsExpanded
+                ? _buildSearchModePanel(colorScheme, textTheme)
+                : const SizedBox(
+                    key: ValueKey('search_mode_panel_empty'),
+                    width: double.infinity,
+                  ),
           ),
           Expanded(child: _buildSearchContent(colorScheme, textTheme)),
         ],
@@ -526,13 +521,12 @@ class _SearchPageState extends ConsumerState<SearchPage> {
             padding: const EdgeInsets.symmetric(vertical: 6),
             child: Column(
               mainAxisSize: MainAxisSize.min,
-              children:
-                  _searchModeOptions
-                      .map(
-                        (option) =>
-                            _buildSearchModeRow(option, colorScheme, textTheme),
-                      )
-                      .toList(),
+              children: _searchModeOptions
+                  .map(
+                    (option) =>
+                        _buildSearchModeRow(option, colorScheme, textTheme),
+                  )
+                  .toList(),
             ),
           ),
         ),
@@ -547,20 +541,18 @@ class _SearchPageState extends ConsumerState<SearchPage> {
   ) {
     final selected = _lastSearchMode == option.mode;
     final enabled = _searchController.text.trim().isNotEmpty;
-    final foreground =
-        !enabled
-            ? colorScheme.onSurfaceVariant.withValues(alpha: 0.45)
-            : selected
-            ? colorScheme.primary
-            : colorScheme.onSurfaceVariant;
+    final foreground = !enabled
+        ? colorScheme.onSurfaceVariant.withValues(alpha: 0.45)
+        : selected
+        ? colorScheme.primary
+        : colorScheme.onSurfaceVariant;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
       child: Material(
-        color:
-            enabled && selected
-                ? colorScheme.primary.withValues(alpha: 0.12)
-                : Colors.transparent,
+        color: enabled && selected
+            ? colorScheme.primary.withValues(alpha: 0.12)
+            : Colors.transparent,
         borderRadius: BorderRadius.circular(12),
         child: InkWell(
           borderRadius: BorderRadius.circular(12),
@@ -579,8 +571,9 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: textTheme.bodyLarge?.copyWith(
-                        fontWeight:
-                            selected ? FontWeight.w700 : FontWeight.w500,
+                        fontWeight: selected
+                            ? FontWeight.w700
+                            : FontWeight.w500,
                       ),
                     ),
                   ),
@@ -651,36 +644,33 @@ class _SearchPageState extends ConsumerState<SearchPage> {
               Wrap(
                 spacing: 8,
                 runSpacing: 8,
-                children:
-                    _history.map((keyword) {
-                      final isPendingDelete = _pendingDeleteItem == keyword;
-                      return GestureDetector(
-                        onTap: () {
-                          if (isPendingDelete) {
-                            _removeFromHistory(keyword);
-                          } else {
-                            _onHistoryTap(keyword);
-                          }
-                        },
-                        onLongPress: () => _onHistoryLongPress(keyword),
-                        child: Chip(
-                          label: Text(
-                            isPendingDelete ? '删除?' : keyword,
-                            style: TextStyle(
-                              color:
-                                  isPendingDelete
-                                      ? colorScheme.error
-                                      : colorScheme.onSurfaceVariant,
-                            ),
-                          ),
-                          backgroundColor:
-                              isPendingDelete
-                                  ? colorScheme.errorContainer
-                                  : colorScheme.surfaceContainerHighest,
-                          side: BorderSide.none,
+                children: _history.map((keyword) {
+                  final isPendingDelete = _pendingDeleteItem == keyword;
+                  return GestureDetector(
+                    onTap: () {
+                      if (isPendingDelete) {
+                        _removeFromHistory(keyword);
+                      } else {
+                        _onHistoryTap(keyword);
+                      }
+                    },
+                    onLongPress: () => _onHistoryLongPress(keyword),
+                    child: Chip(
+                      label: Text(
+                        isPendingDelete ? '删除?' : keyword,
+                        style: TextStyle(
+                          color: isPendingDelete
+                              ? colorScheme.error
+                              : colorScheme.onSurfaceVariant,
                         ),
-                      );
-                    }).toList(),
+                      ),
+                      backgroundColor: isPendingDelete
+                          ? colorScheme.errorContainer
+                          : colorScheme.surfaceContainerHighest,
+                      side: BorderSide.none,
+                    ),
+                  );
+                }).toList(),
               ),
           ],
         ),
@@ -713,10 +703,9 @@ class _SearchPageState extends ConsumerState<SearchPage> {
 
     final startIndex = (_currentFrontendPage - 1) * _pageSize;
     final endIndex = math.min(startIndex + _pageSize, _allValidBooks.length);
-    final displayBooks =
-        startIndex < _allValidBooks.length
-            ? _allValidBooks.sublist(startIndex, endIndex)
-            : <Book>[];
+    final displayBooks = startIndex < _allValidBooks.length
+        ? _allValidBooks.sublist(startIndex, endIndex)
+        : <Book>[];
 
     return CustomScrollView(
       controller: _scrollController,
@@ -765,9 +754,8 @@ class _SearchPageState extends ConsumerState<SearchPage> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Expanded(
-            child: Hero(
+            child: BookCoverHero(
               tag: heroTag,
-              placeholderBuilder: bookCoverHeroPlaceholderBuilder,
               child: BookCoverCard(
                 coverUrl: book.cover,
                 overlays: [

--- a/lib/features/shelf/shelf_folder_page.dart
+++ b/lib/features/shelf/shelf_folder_page.dart
@@ -554,7 +554,6 @@ class _ShelfFolderPageState extends ConsumerState<ShelfFolderPage> {
         heroTag: 'shelf_folder_${widget.folderId}_$bookId',
         telemetrySource: TelemetryBookDetailSources.shelfFolder,
       ),
-      heroTransition: true,
     );
   }
 

--- a/lib/features/shelf/shelf_page.dart
+++ b/lib/features/shelf/shelf_page.dart
@@ -727,7 +727,6 @@ class ShelfPageState extends ConsumerState<ShelfPage> {
         heroTag: 'shelf_cover_$bookId',
         telemetrySource: TelemetryBookDetailSources.shelf,
       ),
-      heroTransition: true,
     );
 
     await _refreshGrid(silentIfPossible: true);

--- a/lib/features/shelf/widgets/shelf_grid_item.dart
+++ b/lib/features/shelf/widgets/shelf_grid_item.dart
@@ -63,7 +63,11 @@ class ShelfBookGridItem extends ConsumerWidget {
           Expanded(
             child:
                 enableHero
-                    ? Hero(tag: heroTag, child: _buildCardContent(context, ref))
+                    ? Hero(
+                      tag: heroTag,
+                      placeholderBuilder: bookCoverHeroPlaceholderBuilder,
+                      child: _buildCardContent(context, ref),
+                    )
                     : _buildCardContent(context, ref),
           ),
           BookGridTitle(title: displayTitle, animated: true),

--- a/lib/features/shelf/widgets/shelf_grid_item.dart
+++ b/lib/features/shelf/widgets/shelf_grid_item.dart
@@ -47,13 +47,12 @@ class ShelfBookGridItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final displayTitle =
-        isInvalid
-            ? '无效书籍'
-            : book?.title ??
-                (shelfTitle?.isNotEmpty == true
-                    ? shelfTitle!
-                    : titleHint ?? '加载中');
+    final displayTitle = isInvalid
+        ? '无效书籍'
+        : book?.title ??
+              (shelfTitle?.isNotEmpty == true
+                  ? shelfTitle!
+                  : titleHint ?? '加载中');
 
     return GestureDetector(
       onTap: onTap,
@@ -61,14 +60,12 @@ class ShelfBookGridItem extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Expanded(
-            child:
-                enableHero
-                    ? Hero(
-                      tag: heroTag,
-                      placeholderBuilder: bookCoverHeroPlaceholderBuilder,
-                      child: _buildCardContent(context, ref),
-                    )
-                    : _buildCardContent(context, ref),
+            child: enableHero
+                ? BookCoverHero(
+                    tag: heroTag,
+                    child: _buildCardContent(context, ref),
+                  )
+                : _buildCardContent(context, ref),
           ),
           BookGridTitle(title: displayTitle, animated: true),
         ],
@@ -87,10 +84,9 @@ class ShelfBookGridItem extends ConsumerWidget {
     return BookCoverCard(
       coverUrl: resolvedCoverUrl,
       elevation: sortMode ? 0 : 2,
-      shadowColor:
-          sortMode
-              ? Colors.transparent
-              : colorScheme.shadow.withValues(alpha: 0.3),
+      shadowColor: sortMode
+          ? Colors.transparent
+          : colorScheme.shadow.withValues(alpha: 0.3),
       showLoading: !isInvalid && (!canResolveNetworkImage || enablePreview),
       resolveNetworkImage: canResolveNetworkImage,
       revealedBefore: coverRevealed,
@@ -161,10 +157,9 @@ class ShelfFolderGridItem extends ConsumerWidget {
                 children: [
                   Card(
                     elevation: sortMode ? 0 : 2,
-                    shadowColor:
-                        sortMode
-                            ? Colors.transparent
-                            : colorScheme.shadow.withValues(alpha: 0.3),
+                    shadowColor: sortMode
+                        ? Colors.transparent
+                        : colorScheme.shadow.withValues(alpha: 0.3),
                     clipBehavior: Clip.antiAlias,
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12),
@@ -174,27 +169,25 @@ class ShelfFolderGridItem extends ConsumerWidget {
                       children: [
                         DecoratedBox(
                           decoration: BoxDecoration(
-                            color:
-                                previewBookIds.isEmpty
-                                    ? colorScheme.secondaryContainer.withValues(
-                                      alpha: 0.6,
-                                    )
-                                    : colorScheme.surfaceContainerHighest,
+                            color: previewBookIds.isEmpty
+                                ? colorScheme.secondaryContainer.withValues(
+                                    alpha: 0.6,
+                                  )
+                                : colorScheme.surfaceContainerHighest,
                           ),
                           child: Padding(
                             padding: const EdgeInsets.all(10),
-                            child:
-                                previewBookIds.isEmpty
-                                    ? _EmptyFolderPreview(
-                                      color: colorScheme.primary,
-                                    )
-                                    : _FolderPreviewGrid(
-                                      previewBookIds: previewBookIds,
-                                      previewBookDetails: previewBookDetails,
-                                      previewBookHints: previewBookHints,
-                                      revealedPreviewKeys: revealedPreviewKeys,
-                                      onPreviewRevealed: onPreviewRevealed,
-                                    ),
+                            child: previewBookIds.isEmpty
+                                ? _EmptyFolderPreview(
+                                    color: colorScheme.primary,
+                                  )
+                                : _FolderPreviewGrid(
+                                    previewBookIds: previewBookIds,
+                                    previewBookDetails: previewBookDetails,
+                                    previewBookHints: previewBookHints,
+                                    revealedPreviewKeys: revealedPreviewKeys,
+                                    onPreviewRevealed: onPreviewRevealed,
+                                  ),
                           ),
                         ),
                         _ShelfCardOverlay(
@@ -354,27 +347,24 @@ class _FolderPreviewSlot extends StatelessWidget {
     return ClipRRect(
       key: ValueKey('folder_preview_${bookId ?? 'empty'}'),
       borderRadius: BorderRadius.circular(6),
-      child:
-          bookId == null
-              ? const _FolderPreviewEmptySlot()
-              : coverUrl?.isNotEmpty == true
-              ? BookCoverImage(
-                imageUrl: coverUrl!,
-                width: double.infinity,
-                height: double.infinity,
-                memCacheWidth: 180,
-                showLoading: true,
-                resolveNetworkImage: canResolveNetworkImage,
-                revealedBefore:
-                    revealKey != null &&
-                    revealedPreviewKeys.contains(revealKey),
-                onRevealed:
-                    revealKey == null || onPreviewRevealed == null
-                        ? null
-                        : () => onPreviewRevealed!(revealKey),
-                animateSynchronouslyLoadedImage: book != null,
-              )
-              : const _FolderPreviewPlaceholder(),
+      child: bookId == null
+          ? const _FolderPreviewEmptySlot()
+          : coverUrl?.isNotEmpty == true
+          ? BookCoverImage(
+              imageUrl: coverUrl!,
+              width: double.infinity,
+              height: double.infinity,
+              memCacheWidth: 180,
+              showLoading: true,
+              resolveNetworkImage: canResolveNetworkImage,
+              revealedBefore:
+                  revealKey != null && revealedPreviewKeys.contains(revealKey),
+              onRevealed: revealKey == null || onPreviewRevealed == null
+                  ? null
+                  : () => onPreviewRevealed!(revealKey),
+              animateSynchronouslyLoadedImage: book != null,
+            )
+          : const _FolderPreviewPlaceholder(),
     );
   }
 }

--- a/lib/src/widgets/book_cover_card.dart
+++ b/lib/src/widgets/book_cover_card.dart
@@ -3,6 +3,22 @@ import 'package:novella/core/widgets/m3e_loading_indicator.dart';
 import 'package:novella/src/widgets/book_cover_image.dart';
 import 'package:novella/src/widgets/book_cover_previewer.dart';
 
+/// Keeps a stranded source Hero visible once its route becomes current again.
+Widget bookCoverHeroPlaceholderBuilder(
+  BuildContext context,
+  Size heroSize,
+  Widget child,
+) {
+  final isCurrentRoute = ModalRoute.of(context)?.isCurrent ?? true;
+  return SizedBox.fromSize(
+    size: heroSize,
+    child: Offstage(
+      offstage: !isCurrentRoute,
+      child: TickerMode(enabled: isCurrentRoute, child: child),
+    ),
+  );
+}
+
 class BookCoverCard extends StatelessWidget {
   final String coverUrl;
   final double elevation;

--- a/lib/src/widgets/book_cover_card.dart
+++ b/lib/src/widgets/book_cover_card.dart
@@ -3,19 +3,166 @@ import 'package:novella/core/widgets/m3e_loading_indicator.dart';
 import 'package:novella/src/widgets/book_cover_image.dart';
 import 'package:novella/src/widgets/book_cover_previewer.dart';
 
-/// Keeps a stranded source Hero visible once its route becomes current again.
+final Map<Object, Set<Object>> _activeBookCoverHeroFlights = {};
+
+class BookCoverHero extends StatelessWidget {
+  final Object tag;
+  final Widget child;
+  final HeroFlightShuttleBuilder? flightShuttleBuilder;
+
+  const BookCoverHero({
+    super.key,
+    required this.tag,
+    required this.child,
+    this.flightShuttleBuilder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Hero(
+      tag: tag,
+      placeholderBuilder: bookCoverHeroPlaceholderBuilder,
+      flightShuttleBuilder: _buildFlightShuttle,
+      child: child,
+    );
+  }
+
+  Widget _buildFlightShuttle(
+    BuildContext flightContext,
+    Animation<double> animation,
+    HeroFlightDirection flightDirection,
+    BuildContext fromHeroContext,
+    BuildContext toHeroContext,
+  ) {
+    final fromRoute = ModalRoute.of(fromHeroContext);
+    final isOverlappingPop =
+        flightDirection == HeroFlightDirection.pop &&
+        (fromRoute?.secondaryAnimation?.status.isAnimating ?? false);
+    if (isOverlappingPop) {
+      return const SizedBox.shrink();
+    }
+
+    final shuttle =
+        flightShuttleBuilder?.call(
+          flightContext,
+          animation,
+          flightDirection,
+          fromHeroContext,
+          toHeroContext,
+        ) ??
+        _buildDefaultFlightShuttle(
+          animation,
+          flightDirection,
+          fromHeroContext,
+          toHeroContext,
+        );
+    final token = Object();
+
+    return _TrackedBookCoverHeroFlight(
+      key: ObjectKey(token),
+      tag: tag,
+      token: token,
+      child: shuttle,
+    );
+  }
+
+  Widget _buildDefaultFlightShuttle(
+    Animation<double> animation,
+    HeroFlightDirection flightDirection,
+    BuildContext fromHeroContext,
+    BuildContext toHeroContext,
+  ) {
+    final toHero = toHeroContext.widget as Hero;
+    final fromMediaQuery = MediaQuery.maybeOf(fromHeroContext);
+    final toMediaQuery = MediaQuery.maybeOf(toHeroContext);
+    if (fromMediaQuery == null || toMediaQuery == null) {
+      return toHero.child;
+    }
+
+    final paddingTween = EdgeInsetsTween(
+      begin: flightDirection == HeroFlightDirection.push
+          ? fromMediaQuery.padding
+          : toMediaQuery.padding,
+      end: flightDirection == HeroFlightDirection.push
+          ? toMediaQuery.padding
+          : fromMediaQuery.padding,
+    );
+
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, _) => MediaQuery(
+        data: toMediaQuery.copyWith(padding: paddingTween.evaluate(animation)),
+        child: toHero.child,
+      ),
+    );
+  }
+}
+
+class _TrackedBookCoverHeroFlight extends StatefulWidget {
+  final Object tag;
+  final Object token;
+  final Widget child;
+
+  const _TrackedBookCoverHeroFlight({
+    super.key,
+    required this.tag,
+    required this.token,
+    required this.child,
+  });
+
+  @override
+  State<_TrackedBookCoverHeroFlight> createState() =>
+      _TrackedBookCoverHeroFlightState();
+}
+
+class _TrackedBookCoverHeroFlightState
+    extends State<_TrackedBookCoverHeroFlight> {
+  @override
+  void initState() {
+    super.initState();
+    _activeBookCoverHeroFlights
+        .putIfAbsent(widget.tag, () => <Object>{})
+        .add(widget.token);
+  }
+
+  @override
+  void dispose() {
+    final flights = _activeBookCoverHeroFlights[widget.tag];
+    flights?.remove(widget.token);
+    if (flights?.isEmpty ?? false) {
+      _activeBookCoverHeroFlights.remove(widget.tag);
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
+/// Keeps a stranded source Hero visible when no matching Hero is in flight.
 Widget bookCoverHeroPlaceholderBuilder(
   BuildContext context,
   Size heroSize,
   Widget child,
 ) {
-  final isCurrentRoute = ModalRoute.of(context)?.isCurrent ?? true;
-  return SizedBox.fromSize(
-    size: heroSize,
-    child: Offstage(
-      offstage: !isCurrentRoute,
-      child: TickerMode(enabled: isCurrentRoute, child: child),
-    ),
+  final route = ModalRoute.of(context);
+  final hero = context.widget;
+  return AnimatedBuilder(
+    animation: Listenable.merge([route?.animation, route?.secondaryAnimation]),
+    builder: (context, _) {
+      final hasActiveFlight =
+          hero is Hero &&
+          (_activeBookCoverHeroFlights[hero.tag]?.isNotEmpty ?? false);
+      final isVisible = (route?.isCurrent ?? true) && !hasActiveFlight;
+
+      return SizedBox.fromSize(
+        size: heroSize,
+        child: Offstage(
+          offstage: !isVisible,
+          child: TickerMode(enabled: isVisible, child: child),
+        ),
+      );
+    },
   );
 }
 

--- a/test/src/widgets/book_cover_card_test.dart
+++ b/test/src/widgets/book_cover_card_test.dart
@@ -8,32 +8,32 @@ void main() {
   ) async {
     final navigatorKey = GlobalKey<NavigatorState>();
     const coverKey = ValueKey('list-cover');
+    const flightKey = ValueKey('rapid-flight-cover');
 
     await tester.pumpWidget(
       MaterialApp(
         navigatorKey: navigatorKey,
         home: Scaffold(
           body: Builder(
-            builder:
-                (context) => Column(
-                  children: [
-                    const Hero(
-                      tag: 'cover',
-                      placeholderBuilder: bookCoverHeroPlaceholderBuilder,
-                      child: SizedBox(key: coverKey, width: 80, height: 120),
-                    ),
-                    TextButton(
-                      onPressed: () {
-                        Navigator.of(context).push<void>(
-                          MaterialPageRoute<void>(
-                            builder: (_) => const _DetailPage(),
-                          ),
-                        );
-                      },
-                      child: const Text('详情'),
-                    ),
-                  ],
+            builder: (context) => Column(
+              children: [
+                const BookCoverHero(
+                  tag: 'cover',
+                  flightShuttleBuilder: _rapidFlightShuttleBuilder,
+                  child: SizedBox(key: coverKey, width: 80, height: 120),
                 ),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).push<void>(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const _DetailPage(),
+                      ),
+                    );
+                  },
+                  child: const Text('详情'),
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -47,6 +47,15 @@ void main() {
     navigatorKey.currentState!
       ..pop()
       ..pop();
+
+    await tester.pump();
+    expect(find.byKey(flightKey), findsNothing);
+    expect(find.byKey(coverKey), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(find.byKey(flightKey), findsNothing);
+    expect(find.byKey(coverKey), findsOneWidget);
+
     await tester.pumpAndSettle();
 
     expect(find.byKey(coverKey), findsOneWidget);
@@ -63,26 +72,25 @@ void main() {
         navigatorKey: navigatorKey,
         home: Scaffold(
           body: Builder(
-            builder:
-                (context) => Column(
-                  children: [
-                    bookCoverHeroPlaceholderBuilder(
-                      context,
-                      const Size(80, 120),
-                      const SizedBox(key: coverKey),
-                    ),
-                    TextButton(
-                      onPressed: () {
-                        Navigator.of(context).push<void>(
-                          MaterialPageRoute<void>(
-                            builder: (_) => const Scaffold(body: Text('下一页')),
-                          ),
-                        );
-                      },
-                      child: const Text('打开'),
-                    ),
-                  ],
+            builder: (context) => Column(
+              children: [
+                bookCoverHeroPlaceholderBuilder(
+                  context,
+                  const Size(80, 120),
+                  const SizedBox(key: coverKey),
                 ),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).push<void>(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const Scaffold(body: Text('下一页')),
+                      ),
+                    );
+                  },
+                  child: const Text('打开'),
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -97,7 +105,89 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byKey(coverKey), findsOneWidget);
   });
+
+  testWidgets('return flight does not paint the destination placeholder', (
+    tester,
+  ) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+    const listCoverKey = ValueKey('list-cover-during-flight');
+    const flightCoverKey = ValueKey('flight-cover');
+
+    Widget flightShuttleBuilder(
+      BuildContext flightContext,
+      Animation<double> animation,
+      HeroFlightDirection flightDirection,
+      BuildContext fromHeroContext,
+      BuildContext toHeroContext,
+    ) => const SizedBox(key: flightCoverKey, width: 100, height: 150);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Column(
+              children: [
+                BookCoverHero(
+                  tag: 'cover',
+                  flightShuttleBuilder: flightShuttleBuilder,
+                  child: const SizedBox(
+                    key: listCoverKey,
+                    width: 80,
+                    height: 120,
+                  ),
+                ),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).push<void>(
+                      MaterialPageRoute<void>(
+                        builder: (_) => Scaffold(
+                          body: Hero(
+                            tag: 'cover',
+                            flightShuttleBuilder: flightShuttleBuilder,
+                            child: const SizedBox(width: 100, height: 150),
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('详情'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('详情'));
+    await tester.pumpAndSettle();
+
+    navigatorKey.currentState!.pop();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.byKey(flightCoverKey), findsOneWidget);
+    expect(find.byKey(listCoverKey), findsNothing);
+    expect(find.byKey(listCoverKey, skipOffstage: false), findsOneWidget);
+
+    await tester.pumpAndSettle();
+    expect(find.byKey(flightCoverKey), findsNothing);
+    expect(find.byKey(listCoverKey), findsOneWidget);
+  });
 }
+
+Widget _rapidFlightShuttleBuilder(
+  BuildContext flightContext,
+  Animation<double> animation,
+  HeroFlightDirection flightDirection,
+  BuildContext fromHeroContext,
+  BuildContext toHeroContext,
+) => const SizedBox(
+  key: ValueKey('rapid-flight-cover'),
+  width: 100,
+  height: 150,
+);
 
 class _DetailPage extends StatelessWidget {
   const _DetailPage();

--- a/test/src/widgets/book_cover_card_test.dart
+++ b/test/src/widgets/book_cover_card_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:novella/src/widgets/book_cover_card.dart';
+
+void main() {
+  testWidgets('rapid consecutive pops keep the list cover visible', (
+    tester,
+  ) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+    const coverKey = ValueKey('list-cover');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: Scaffold(
+          body: Builder(
+            builder:
+                (context) => Column(
+                  children: [
+                    const Hero(
+                      tag: 'cover',
+                      placeholderBuilder: bookCoverHeroPlaceholderBuilder,
+                      child: SizedBox(key: coverKey, width: 80, height: 120),
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        Navigator.of(context).push<void>(
+                          MaterialPageRoute<void>(
+                            builder: (_) => const _DetailPage(),
+                          ),
+                        );
+                      },
+                      child: const Text('详情'),
+                    ),
+                  ],
+                ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('详情'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('评论'));
+    await tester.pumpAndSettle();
+
+    navigatorKey.currentState!
+      ..pop()
+      ..pop();
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(coverKey), findsOneWidget);
+  });
+
+  testWidgets('placeholder retains the cover while its route is covered', (
+    tester,
+  ) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+    const coverKey = ValueKey('placeholder-cover');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: Scaffold(
+          body: Builder(
+            builder:
+                (context) => Column(
+                  children: [
+                    bookCoverHeroPlaceholderBuilder(
+                      context,
+                      const Size(80, 120),
+                      const SizedBox(key: coverKey),
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        Navigator.of(context).push<void>(
+                          MaterialPageRoute<void>(
+                            builder: (_) => const Scaffold(body: Text('下一页')),
+                          ),
+                        );
+                      },
+                      child: const Text('打开'),
+                    ),
+                  ],
+                ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('打开'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(coverKey), findsNothing);
+    expect(find.byKey(coverKey, skipOffstage: false), findsOneWidget);
+
+    navigatorKey.currentState!.pop();
+    await tester.pumpAndSettle();
+    expect(find.byKey(coverKey), findsOneWidget);
+  });
+}
+
+class _DetailPage extends StatelessWidget {
+  const _DetailPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: [
+          const Hero(tag: 'cover', child: SizedBox(width: 100, height: 150)),
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).push<void>(
+                MaterialPageRoute<void>(
+                  builder: (_) => const Scaffold(body: Text('评论页')),
+                ),
+              );
+            },
+            child: const Text('评论'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- keep list-side book covers visible if a rapid consecutive pop leaves a source Hero in its placeholder state
- apply the shared placeholder builder to cover Heroes on home, recently updated, ranking, search, shelf, folder, and history surfaces
- remove the Android-only Zoom route workaround so detail navigation uses the normal route transition and predictive back remains available
- add regression coverage for rapid consecutive pops and placeholder visibility

## Root cause

Rapidly returning from the comment page through book details can leave the source Hero mounted with a non-null placeholder after its list route becomes current again. The image is still loaded, but Flutter continues rendering the empty placeholder, so the cover appears blank.

The placeholder now retains the cover offstage while its route is covered and reveals it whenever that route becomes current again.

## Validation

- `flutter analyze` on all touched Dart files
- `flutter test` (107 tests)
- `flutter build apk --debug`
- Android 16 physical-device verification: detail -> comment -> two rapid back actions, with all list covers remaining visible
